### PR TITLE
Add ring element to the gameplay element

### DIFF
--- a/maisim/maisim.Game.Tests/Visual/Component/Gameplay/TestSceneMaisimRing.cs
+++ b/maisim/maisim.Game.Tests/Visual/Component/Gameplay/TestSceneMaisimRing.cs
@@ -1,0 +1,29 @@
+using maisim.Game.Component.Gameplay;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace maisim.Game.Tests.Visual.Component.Gameplay
+{
+    public class TestSceneMaisimRing : maisimTestScene
+    {
+        public TestSceneMaisimRing()
+        {
+            Child = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(1),
+                Children = new Drawable[]
+                {
+                    new MaisimRing
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(1),
+                    }
+                }
+            };
+        }
+    }
+}

--- a/maisim/maisim.Game/Component/Gameplay/MaisimRing.cs
+++ b/maisim/maisim.Game/Component/Gameplay/MaisimRing.cs
@@ -37,7 +37,7 @@ namespace maisim.Game.Component.Gameplay
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.Pink,
+                    Colour = Color4.DarkCyan,
                     BorderThickness = 10,
                     BorderColour = Color4.Green,
                     Masking = true

--- a/maisim/maisim.Game/Component/Gameplay/MaisimRing.cs
+++ b/maisim/maisim.Game/Component/Gameplay/MaisimRing.cs
@@ -1,0 +1,33 @@
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace maisim.Game.Component.Gameplay
+{
+    public class MaisimRing : CircularContainer
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Size = new Vector2(250, 250);
+            Children = new Drawable[]
+            {
+                new Circle()
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.White,
+                    BorderThickness = 10,
+                    BorderColour = Color4.Pink,
+                    Masking = true
+                }
+            };
+        }
+    }
+}

--- a/maisim/maisim.Game/Component/Gameplay/MaisimRing.cs
+++ b/maisim/maisim.Game/Component/Gameplay/MaisimRing.cs
@@ -1,3 +1,4 @@
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -9,25 +10,61 @@ namespace maisim.Game.Component.Gameplay
 {
     public class MaisimRing : CircularContainer
     {
+        private static readonly float[] lane_angles =
+        {
+            22.5f,
+            67.5f,
+            112.5f,
+            157.5f,
+            202.5f,
+            247.5f,
+            292.5f,
+            337.5f
+        };
+
+        private static readonly float LANE_MULTIPLIER = 284.5f; // TODO: Still not sure on this. But when the outline circle is working, this should be changed too.
+
         [BackgroundDependencyLoader]
         private void load()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            Size = new Vector2(250, 250);
+            Size = new Vector2(580, 580);
             Children = new Drawable[]
             {
-                new Circle()
+                new Circle
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.White,
+                    Colour = Color4.Pink,
                     BorderThickness = 10,
-                    BorderColour = Color4.Pink,
+                    BorderColour = Color4.Green,
                     Masking = true
                 }
             };
+
+            foreach (float angle in lane_angles)
+            {
+                AddInternal(new Circle
+                {
+                    Position = new Vector2(
+                        -(LANE_MULTIPLIER * (float)Math.Cos((angle + 90f) * (float)(Math.PI / 180))),
+                        -(LANE_MULTIPLIER * (float)Math.Sin((angle + 90f) * (float)(Math.PI / 180)))
+                    ),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(10)
+                });
+            }
+
+            AddInternal(new Circle
+            {
+                Position = Vector2.Zero,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(10),
+            });
         }
     }
 }


### PR DESCRIPTION
Add the ring element that's a main playfield on main gameplay field.

![image](https://user-images.githubusercontent.com/68165621/153770357-a25748b2-f991-4368-ba57-277edf3b7c73.png)

# Problem

The Maimai playfield is mainly a circle white the white border and the 'sensor' on the ring corner. So I try using this method

```csharp
new Circle
{
    Anchor = Anchor.Centre,
    Origin = Anchor.Centre,
    RelativeSizeAxes = Axes.Both,
    Colour = Color4.White.Opacity(0.5f),
    BorderThickness = 10,
    BorderColour = Color4.White,
    Masking = true
}
```

And the result is like this

![image](https://user-images.githubusercontent.com/68165621/153770819-77461bbd-fd52-446d-881c-b16f3160c3c3.png)

The goal of this ring is it must have only the white border and its circle color must be transparent or only white with very low transparency but when I using this method the border color is depend on the transparency using inside the circle (like I set inside as 0.5f so the border is 0.5f too) Needing to investigate on this.
