### PR TITLE
Change .NET project version to target .NET 6.0

### DIFF
--- a/maisim/maisim.Desktop/maisim.Desktop.csproj
+++ b/maisim/maisim.Desktop/maisim.Desktop.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup Label="Project">
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>WinExe</OutputType>
         <AssemblyName>maisim</AssemblyName>
         <ApplicationIcon>game.ico</ApplicationIcon>

--- a/maisim/maisim.Game.Tests/maisim.Game.Tests.csproj
+++ b/maisim/maisim.Game.Tests/maisim.Game.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup Label="Project">
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateProgramFile>false</GenerateProgramFile>
     </PropertyGroup>
     <ItemGroup Label="Project References">


### PR DESCRIPTION
After bump the framework to latest version in #10 and #11 that's just bumping to .NET 6.0 now we can change the .NET version to target .NET 6.0 and I check on the breaking and no breaking change. But want to make sure so I make a new pull request for this.