### PR TITLE
Add Continuous Integration to GitHub Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,50 @@
+on: [push, pull_request]
+name: Continuous Integration
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{matrix.os.fullname}}
+    strategy:
+       fail-fast: false
+       matrix:
+          os:
+            - { prettyname: Windows, fullname: windows-latest }
+            - { prettyname: macOS, fullname: macos-latest }
+            - { prettyname: Linux, fullname: ubuntu-latest }
+    timeout-minutes: 60
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install .NET 6.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: "6.0.x"
+    
+    # https://github.com/ppy/osu-framework/issues/4349
+    - name: Install libavformat-dev
+        if: ${{matrix.os.fullname == 'ubuntu-latest'}}
+        run: |
+         sudo apt-get update && \
+         sudo apt-get -y install libavformat-dev
+    
+    - name: Restore dependencies
+      run: dotnet restore
+    
+    - name: Build
+        run: dotnet build -c Debug -warnaserror build/Desktop.proj
+    
+    - name: Test
+        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"
+        shell: pwsh
+    
+    # Attempt to upload results even if test fails.
+    # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: maisim-test-results-${{matrix.os.prettyname}}
+        path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}.trx

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
        fail-fast: false
        matrix:
-          os:
+         os:
             - { prettyname: Windows, fullname: windows-latest }
             - { prettyname: macOS, fullname: macos-latest }
             - { prettyname: Linux, fullname: ubuntu-latest }
@@ -25,20 +25,20 @@ jobs:
     
     # https://github.com/ppy/osu-framework/issues/4349
     - name: Install libavformat-dev
-        if: ${{matrix.os.fullname == 'ubuntu-latest'}}
-        run: |
-         sudo apt-get update && \
-         sudo apt-get -y install libavformat-dev
+      if: ${{matrix.os.fullname == 'ubuntu-latest'}}
+      run: |
+       sudo apt-get update && \
+       sudo apt-get -y install libavformat-dev
     
     - name: Restore dependencies
       run: dotnet restore
     
     - name: Build
-        run: dotnet build -c Debug -warnaserror build/Desktop.proj
+      run: dotnet build -c Debug -warnaserror build/Desktop.proj
     
     - name: Test
-        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"
-        shell: pwsh
+      run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"
+      shell: pwsh
     
     # Attempt to upload results even if test fails.
     # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,6 @@ jobs:
   test:
     name: Test
     runs-on: ${{matrix.os.fullname}}
-    continue-on-error: true
     strategy:
        fail-fast: false
        matrix:
@@ -36,6 +35,7 @@ jobs:
     
     # Build on iOS is failes so we need to allow continue-on-error
     - name: Build
+      continue-on-error: true
       run: |
         dotnet build -c Debug
     

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,14 +40,5 @@ jobs:
         dotnet build -c Debug
     
     - name: Test
-      run: dotnet test
+      run: dotnet test maisim.Desktop.slnf
       shell: pwsh
-    
-    # Attempt to upload results even if test fails.
-    # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always
-    - name: Upload Test Results
-      uses: actions/upload-artifact@v2
-      if: ${{ always() }}
-      with:
-        name: maisim-test-results-${{matrix.os.prettyname}}
-        path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}.trx

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,9 +35,9 @@ jobs:
     
     # Build on iOS is failes so we need to allow continue-on-error
     - name: Build
-      continue-on-error: true
       run: |
-        dotnet build -c Debug
+        cd maisim
+        dotnet build -c Debug maisim.Desktop.slnf
     
     - name: Test
       run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,5 +40,7 @@ jobs:
         dotnet build -c Debug
     
     - name: Test
-      run: dotnet test maisim.Desktop.slnf
+      run: |
+        cd maisim
+        dotnet test maisim.Desktop.slnf
       shell: pwsh

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,7 +34,9 @@ jobs:
       run: dotnet restore
     
     - name: Build
-      run: dotnet build -c Debug -warnaserror build/Desktop.proj
+      run: |
+        cd maisim
+        dotnet build -c Debug -warnaserror build/Desktop.proj
     
     - name: Test
       run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build
       run: |
         cd maisim
-        dotnet build -c Debug -warnaserror build/Desktop.proj
+        dotnet build -c Debug -warnaserror maisim.Desktop.slnf
     
     - name: Test
       run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     name: Test
     runs-on: ${{matrix.os.fullname}}
+    continue-on-error: true
     strategy:
        fail-fast: false
        matrix:
@@ -33,6 +34,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     
+    # Build on iOS is failes so we need to allow continue-on-error
     - name: Build
       run: |
         dotnet build -c Debug

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,7 +40,7 @@ jobs:
         dotnet build -c Debug
     
     - name: Test
-      run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"
+      run: dotnet test
       shell: pwsh
     
     # Attempt to upload results even if test fails.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,8 +35,7 @@ jobs:
     
     - name: Build
       run: |
-        cd maisim
-        dotnet build -c Debug -warnaserror maisim.Desktop.slnf
+        dotnet build -c Debug
     
     - name: Test
       run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"


### PR DESCRIPTION
Add dotnet test for testing on push and pull requests to GitHub Actions.

Result example : https://github.com/HelloYeew/maisim/actions/runs/1882319186

Edit : After I tried to make iOS possible to build and test and failed so I currently target to build only desktop.