### PR TITLE
Fix deprecate `GameHost` warning

### DIFF
--- a/maisim/maisim.Desktop/Program.cs
+++ b/maisim/maisim.Desktop/Program.cs
@@ -8,7 +8,7 @@ namespace maisim.Desktop
     {
         public static void Main()
         {
-            using (GameHost host = Host.GetSuitableHost(@"maisim"))
+            using (GameHost host = Host.GetSuitableDesktopHost("maisim", new HostOptions { BindIPC = true }))
             using (osu.Framework.Game game = new maisimGame())
                 host.Run(new maisimGameDesktop());
         }

--- a/maisim/maisim.Game.Tests/Program.cs
+++ b/maisim/maisim.Game.Tests/Program.cs
@@ -7,7 +7,7 @@ namespace maisim.Game.Tests
     {
         public static void Main()
         {
-            using (GameHost host = Host.GetSuitableHost("visual-tests"))
+            using (GameHost host = Host.GetSuitableDesktopHost("maisim-test", new HostOptions { BindIPC = true }))
             using (var game = new maisimTestBrowser())
                 host.Run(game);
         }


### PR DESCRIPTION
Change `Host.GetSuitableHost` to `Host.GetSuitableDesktopHost` as the warning error during build say.