### PR TITLE
Initialize the note spawner class and its property

### DIFF
--- a/maisim/maisim.Game.Tests/Visual/Component/Gameplay/TestSceneNoteSpawner.cs
+++ b/maisim/maisim.Game.Tests/Visual/Component/Gameplay/TestSceneNoteSpawner.cs
@@ -1,0 +1,36 @@
+﻿using maisim.Game.Component.Gameplay;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace maisim.Game.Tests.Visual.Component.Gameplay;
+
+public class TestSceneNoteSpawner : maisimTestScene
+{
+    private readonly NoteSpawnerRing noteSpawnerRing;
+
+    public TestSceneNoteSpawner()
+    {
+        Child = new Container
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Size = new Vector2(1),
+            Children = new Drawable[]
+            {
+                new MaisimRing
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(1),
+                },noteSpawnerRing = new NoteSpawnerRing
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(1),
+                    ShowSpawners = true
+                }
+            }
+        };
+    }
+}

--- a/maisim/maisim.Game/Component/Gameplay/MaisimRing.cs
+++ b/maisim/maisim.Game/Component/Gameplay/MaisimRing.cs
@@ -10,7 +10,7 @@ namespace maisim.Game.Component.Gameplay
 {
     public class MaisimRing : CircularContainer
     {
-        private static readonly float[] lane_angles =
+        public static readonly float[] LANE_ANGLES =
         {
             22.5f,
             67.5f,
@@ -24,12 +24,14 @@ namespace maisim.Game.Component.Gameplay
 
         private static readonly float LANE_MULTIPLIER = 284.5f; // TODO: Still not sure on this. But when the outline circle is working, this should be changed too.
 
+        public static readonly Vector2 PLAYFIELD_SIZE = new Vector2(580, 580);
+
         [BackgroundDependencyLoader]
         private void load()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            Size = new Vector2(580, 580);
+            Size = PLAYFIELD_SIZE;
             Children = new Drawable[]
             {
                 new Circle
@@ -44,7 +46,7 @@ namespace maisim.Game.Component.Gameplay
                 }
             };
 
-            foreach (float angle in lane_angles)
+            foreach (float angle in LANE_ANGLES)
             {
                 AddInternal(new Circle
                 {

--- a/maisim/maisim.Game/Component/Gameplay/NoteSpawner.cs
+++ b/maisim/maisim.Game/Component/Gameplay/NoteSpawner.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Allocation;
+﻿using maisim.Game.Component.Gameplay.Notes;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -7,10 +8,19 @@ using osuTK.Graphics;
 
 namespace maisim.Game.Component.Gameplay
 {
+    /// <summary>
+    /// A spawner that spawn a <see cref="DrawableNote"/> at its position.
+    /// </summary>
     public class NoteSpawner : CircularContainer
     {
+        /// <summary>
+        /// Show the spawner location as a small circle.
+        /// </summary>
         public bool ShowOutline { get; set; }
 
+        /// <summary>
+        /// Target that the spawner is spawning notes for.
+        /// </summary>
         public float TargetAngles { get; set; }
 
         [BackgroundDependencyLoader]

--- a/maisim/maisim.Game/Component/Gameplay/NoteSpawner.cs
+++ b/maisim/maisim.Game/Component/Gameplay/NoteSpawner.cs
@@ -1,0 +1,39 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace maisim.Game.Component.Gameplay
+{
+    public class NoteSpawner : CircularContainer
+    {
+        public bool ShowOutline { get; set; } = false;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Size = new Vector2(1,1);
+
+            if (ShowOutline)
+            {
+                Child = new Circle
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.White,
+                    Size = new Vector2(5)
+                };
+            }
+        }
+
+        private Vector2 position()
+        {
+            return new Vector2(Position.X, Position.Y);
+        }
+    }
+}

--- a/maisim/maisim.Game/Component/Gameplay/NoteSpawner.cs
+++ b/maisim/maisim.Game/Component/Gameplay/NoteSpawner.cs
@@ -9,7 +9,9 @@ namespace maisim.Game.Component.Gameplay
 {
     public class NoteSpawner : CircularContainer
     {
-        public bool ShowOutline { get; set; } = false;
+        public bool ShowOutline { get; set; }
+
+        public float TargetAngles { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -29,11 +31,6 @@ namespace maisim.Game.Component.Gameplay
                     Size = new Vector2(5)
                 };
             }
-        }
-
-        private Vector2 position()
-        {
-            return new Vector2(Position.X, Position.Y);
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/NoteSpawnerRing.cs
+++ b/maisim/maisim.Game/Component/Gameplay/NoteSpawnerRing.cs
@@ -6,10 +6,19 @@ using osuTK;
 
 namespace maisim.Game.Component.Gameplay
 {
+    /// <summary>
+    /// A circle that include <see cref="NoteSpawner"/> that is target to angles in <see cref="MaisimRing"/>.
+    ///
+    /// This spawner use to spawn a note that's spawn from the center of the playfield. (TAP, BREAK, HOLD)
+    /// </summary>
     public class NoteSpawnerRing : CircularContainer
     {
+        // TODO: Make more clarification from Maimai player on the size of spawner ring.
         private static readonly float SPAWNER_MULTIPLIER = 75f;
 
+        /// <summary>
+        /// Show ring of spawner and all spawner.
+        /// </summary>
         public bool ShowSpawners { get; set; }
 
         [BackgroundDependencyLoader]

--- a/maisim/maisim.Game/Component/Gameplay/NoteSpawnerRing.cs
+++ b/maisim/maisim.Game/Component/Gameplay/NoteSpawnerRing.cs
@@ -10,9 +10,7 @@ namespace maisim.Game.Component.Gameplay
     {
         private static readonly float SPAWNER_MULTIPLIER = 75f;
 
-        private readonly NoteSpawner[] spawners;
-
-        public bool ShowSpawners { get; set; } = false;
+        public bool ShowSpawners { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -32,6 +30,7 @@ namespace maisim.Game.Component.Gameplay
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Size = new Vector2(2),
+                    TargetAngles = angle,
                     ShowOutline = ShowSpawners
                 });
             }

--- a/maisim/maisim.Game/Component/Gameplay/NoteSpawnerRing.cs
+++ b/maisim/maisim.Game/Component/Gameplay/NoteSpawnerRing.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace maisim.Game.Component.Gameplay
+{
+    public class NoteSpawnerRing : CircularContainer
+    {
+        private static readonly float SPAWNER_MULTIPLIER = 75f;
+
+        private readonly NoteSpawner[] spawners;
+
+        public bool ShowSpawners { get; set; } = false;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Size = MaisimRing.PLAYFIELD_SIZE;
+
+            foreach (var angle in MaisimRing.LANE_ANGLES)
+            {
+                AddInternal(new NoteSpawner
+                {
+                    Position = new Vector2(
+                        -(SPAWNER_MULTIPLIER * (float)Math.Cos((angle + 90f) * (float)(Math.PI / 180))),
+                        -(SPAWNER_MULTIPLIER * (float)Math.Sin((angle + 90f) * (float)(Math.PI / 180)))
+                    ),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(2),
+                    ShowOutline = ShowSpawners
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Initialize the `NoteSpawner` class that's act as the location that will spawn the note to the playfield.
- Initialzie the `NoteSpawnerRing` that act as the spawner for the note that spawn from the center of the playfield and other sensor or spawner like TOUCH note spawner ring will implement like this way too. Also add the test scene for this.

This PRs is a bit small but I want to make sure on the way that I implement it.