### PR TITLE
Add logic to make `Playfield` can spawn note from a target time

### DIFF
--- a/maisim/maisim.Game.Tests/Visual/Component/Gameplay/TestSceneGameplayElement.cs
+++ b/maisim/maisim.Game.Tests/Visual/Component/Gameplay/TestSceneGameplayElement.cs
@@ -18,12 +18,7 @@ namespace maisim.Game.Tests.Visual.Component.Gameplay
                     Origin = Anchor.TopLeft,
                     Text = nameof(DrawableTapNote)
                 },
-                new DrawableTapNote
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Scale = new Vector2(1.5f)
-                }
+                new DrawableTapNote()
             };
 
             Cell(0, 1).Children = new Drawable[]

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using maisim.Game.Component.Gameplay.Notes;
+using maisim.Game.Screen.Gameplay;
+using maisim.Game.Utils;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osuTK;
+
+namespace maisim.Game.Tests.Visual.Screen;
+
+public class TestSceneNoteSpawnTimer : maisimTestScene
+{
+    private PlayfieldScreen playfieldScreen;
+
+    private Random random = new Random();
+
+    [SetUp]
+    public void SetUp()
+    {
+        Add(playfieldScreen = new PlayfieldScreen {RelativeSizeAxes = Axes.Both});
+
+        playfieldScreen.Playfield.NotesPool = new List<DrawableNote>
+        {
+            new DrawableTapNote()
+            {
+                Lane = NoteLane.Lane1,
+                TargetTime = 5000f
+            },
+            new DrawableTapNote()
+            {
+                Lane = NoteLane.Lane2,
+                TargetTime = 7000f
+            },
+            new DrawableTapNote()
+            {
+                Lane = NoteLane.Lane3,
+                TargetTime = 9000f
+            },
+            new DrawableTapNote()
+            {
+                Lane = NoteLane.Lane4,
+                TargetTime = 11000f
+            },
+            new DrawableTapNote()
+            {
+                Lane = NoteLane.Lane5,
+                TargetTime = 13000f
+            },
+            new DrawableTapNote()
+            {
+                Lane = NoteLane.Lane6,
+                TargetTime = 15000f
+            },
+        };
+    }
+}

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using maisim.Game.Component.Gameplay.Notes;
 using maisim.Game.Screen.Gameplay;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
@@ -2,18 +2,14 @@
 using System.Collections.Generic;
 using maisim.Game.Component.Gameplay.Notes;
 using maisim.Game.Screen.Gameplay;
-using maisim.Game.Utils;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osuTK;
 
 namespace maisim.Game.Tests.Visual.Screen;
 
 public class TestSceneNoteSpawnTimer : maisimTestScene
 {
     private PlayfieldScreen playfieldScreen;
-
-    private Random random = new Random();
 
     [SetUp]
     public void SetUp()

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using maisim.Game.Component.Gameplay.Notes;
 using maisim.Game.Screen.Gameplay;
 using NUnit.Framework;

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
@@ -15,7 +15,6 @@ public class TestSceneNoteSpawnTimer : maisimTestScene
     {
         Add(playfieldScreen = new PlayfieldScreen {RelativeSizeAxes = Axes.Both});
 
-
         playfieldScreen.Playfield.NotesPool = new List<DrawableNote>
         {
             new DrawableTapNote()

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using maisim.Game.Component.Gameplay.Notes;
 using maisim.Game.Screen.Gameplay;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 
 namespace maisim.Game.Tests.Visual.Screen;
@@ -10,43 +12,22 @@ public class TestSceneNoteSpawnTimer : maisimTestScene
 {
     private PlayfieldScreen playfieldScreen;
 
-    [SetUp]
-    public void SetUp()
-    {
-        Add(playfieldScreen = new PlayfieldScreen {RelativeSizeAxes = Axes.Both});
 
-        playfieldScreen.Playfield.NotesPool = new List<DrawableNote>
-        {
-            new DrawableTapNote()
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        Add(playfieldScreen = new PlayfieldScreen { RelativeSizeAxes = Axes.Both });
+        AddStep("spawn notes", spawnNotes);
+    }
+
+    private void spawnNotes()
+    {
+        playfieldScreen.Playfield.Children = Enumerable.Range(0, (int)NoteLane.Lane8).Select<int, Drawable>(i =>
+            new DrawableTapNote
             {
-                Lane = NoteLane.Lane1,
-                TargetTime = 5000f
-            },
-            new DrawableTapNote()
-            {
-                Lane = NoteLane.Lane2,
-                TargetTime = 7000f
-            },
-            new DrawableTapNote()
-            {
-                Lane = NoteLane.Lane3,
-                TargetTime = 9000f
-            },
-            new DrawableTapNote()
-            {
-                Lane = NoteLane.Lane4,
-                TargetTime = 11000f
-            },
-            new DrawableTapNote()
-            {
-                Lane = NoteLane.Lane5,
-                TargetTime = 13000f
-            },
-            new DrawableTapNote()
-            {
-                Lane = NoteLane.Lane6,
-                TargetTime = 15000f
-            },
-        };
+                Lane = (NoteLane)i,
+                TargetTime = Clock.CurrentTime + i * 1000
+            }
+        ).ToList().AsReadOnly();
     }
 }

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestSceneNoteSpawnTimer.cs
@@ -16,6 +16,7 @@ public class TestSceneNoteSpawnTimer : maisimTestScene
     {
         Add(playfieldScreen = new PlayfieldScreen {RelativeSizeAxes = Axes.Both});
 
+
         playfieldScreen.Playfield.NotesPool = new List<DrawableNote>
         {
             new DrawableTapNote()

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestScenePlayfieldScreen.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestScenePlayfieldScreen.cs
@@ -4,7 +4,6 @@ using maisim.Game.Screen.Gameplay;
 using maisim.Game.Utils;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osuTK;
 
 namespace maisim.Game.Tests.Visual.Screen
 {

--- a/maisim/maisim.Game.Tests/Visual/Screen/TestScenePlayfieldScreen.cs
+++ b/maisim/maisim.Game.Tests/Visual/Screen/TestScenePlayfieldScreen.cs
@@ -18,15 +18,6 @@ namespace maisim.Game.Tests.Visual.Screen
         public void SetUp()
         {
             Add(playfieldScreen = new PlayfieldScreen {RelativeSizeAxes = Axes.Both});
-
-            AddStep("random spawn note", () => playfieldScreen.Playfield.SpawnNote(new DrawableTouchNote
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Position = new Vector2(random.NextFloatInRange(-300.0f, 300.0f),
-                    random.NextFloatInRange(-300.0f, 300.0f)),
-                Scale = new Vector2(1.5f)
-            }));
             AddStep("spawn tap note on lane 1", () => playfieldScreen.Playfield.SpawnTapNote(NoteLane.Lane1));
             AddStep("spawn tap note on lane 2", () => playfieldScreen.Playfield.SpawnTapNote(NoteLane.Lane2));
             AddStep("spawn tap note on lane 3", () => playfieldScreen.Playfield.SpawnTapNote(NoteLane.Lane3));

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableBreakNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableBreakNote.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Graphics;
+﻿using maisim.Game.Screen.Gameplay;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 
@@ -22,6 +23,11 @@ namespace maisim.Game.Component.Gameplay.Notes
                     Texture = textureStore.Get("Notes/Break.png")
                 }
             };
+        }
+
+        public override void UpdatePosition(Playfield playfield)
+        {
+
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableBreakNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableBreakNote.cs
@@ -25,11 +25,6 @@ namespace maisim.Game.Component.Gameplay.Notes
             };
         }
 
-        public override void UpdatePosition(Playfield playfield)
-        {
-
-        }
-
         public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableBreakNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableBreakNote.cs
@@ -30,9 +30,6 @@ namespace maisim.Game.Component.Gameplay.Notes
 
         }
 
-        public override bool CanDespawn()
-        {
-            return false;
-        }
+        public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableBreakNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableBreakNote.cs
@@ -29,5 +29,10 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
 
         }
+
+        public override bool CanDespawn()
+        {
+            return false;
+        }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
@@ -17,7 +17,7 @@ namespace maisim.Game.Component.Gameplay.Notes
     {
         public NoteLane Lane { get; set; }
 
-        protected readonly Bindable<NoteActivationState> State = new Bindable<NoteActivationState>(NoteActivationState.Inactive);
+        protected readonly Bindable<NoteActivationState> State = new Bindable<NoteActivationState>();
 
         [BackgroundDependencyLoader]
         private void load(TextureStore textureStore)

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Allocation;
+﻿using maisim.Game.Screen.Gameplay;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
@@ -34,5 +35,10 @@ namespace maisim.Game.Component.Gameplay.Notes
         /// The time that the note need to be hit.
         /// </summary>
         public double TargetTime;
+
+        /// <summary>
+        /// Update the note position.
+        /// </summary>
+        public abstract void UpdatePosition(Playfield playfield);
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
@@ -45,6 +45,6 @@ namespace maisim.Game.Component.Gameplay.Notes
         /// Check that the note can start to despawn state.
         /// </summary>
         /// <returns>True if the note can start despawn state.</returns>
-        public abstract bool CanDespawn();
+        public abstract bool CanDespawn { get; }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
@@ -40,5 +40,11 @@ namespace maisim.Game.Component.Gameplay.Notes
         /// Update the note position.
         /// </summary>
         public abstract void UpdatePosition(Playfield playfield);
+
+        /// <summary>
+        /// Check that the note can start to despawn state.
+        /// </summary>
+        /// <returns>True if the note can start despawn state.</returns>
+        public abstract bool CanDespawn();
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
@@ -29,5 +29,10 @@ namespace maisim.Game.Component.Gameplay.Notes
         /// <param name="textureStore"><see cref="TextureStore"/> in load operation.</param>
         /// <returns>List of drawable include all note part that will be initialize on load.</returns>
         protected abstract Drawable[] AddNoteParts(TextureStore textureStore);
+
+        /// <summary>
+        /// The time that the note need to be hit.
+        /// </summary>
+        public double TargetTime;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
@@ -16,7 +16,6 @@ namespace maisim.Game.Component.Gameplay.Notes
     public abstract class DrawableNote : CompositeDrawable
     {
         public readonly double FADE_IN_TIME = 75f;
-        public readonly double FADE_OUT_TIME = 50f;
 
         public NoteLane Lane { get; set; }
 

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
@@ -1,5 +1,8 @@
-﻿using maisim.Game.Screen.Gameplay;
+﻿using System;
+using maisim.Game.Screen.Gameplay;
+using maisim.Game.Utils;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
@@ -12,6 +15,10 @@ namespace maisim.Game.Component.Gameplay.Notes
     /// </summary>
     public abstract class DrawableNote : CompositeDrawable
     {
+        public NoteLane Lane { get; set; }
+
+        protected readonly Bindable<NoteActivationState> State = new Bindable<NoteActivationState>(NoteActivationState.Inactive);
+
         [BackgroundDependencyLoader]
         private void load(TextureStore textureStore)
         {
@@ -22,6 +29,14 @@ namespace maisim.Game.Component.Gameplay.Notes
                 Size = new Vector2(50),
                 Children = AddNoteParts(textureStore)
             };
+
+            // hide the note by default
+            Hide();
+
+            //required to handle state updates when hidden.
+            AlwaysPresent = true;
+
+            State.BindValueChanged(UpdateActivationState);
         }
 
         /// <summary>
@@ -37,14 +52,78 @@ namespace maisim.Game.Component.Gameplay.Notes
         public double TargetTime;
 
         /// <summary>
-        /// Update the note position.
-        /// </summary>
-        public abstract void UpdatePosition(Playfield playfield);
-
-        /// <summary>
         /// Check that the note can start to despawn state.
         /// </summary>
         /// <returns>True if the note can start despawn state.</returns>
         public abstract bool CanDespawn { get; }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // note active state should become Active when the clock time reaches near the target time
+            if (Clock.TimeInfo.Current >= TargetTime - Playfield.TIME_NOTE_APPEARS && State.Value == NoteActivationState.Inactive)
+                State.Value = NoteActivationState.Active;
+            
+            if (State.Value == NoteActivationState.Active)
+                UpdatePosition();
+
+            if (CanDespawn)
+                State.Value = NoteActivationState.Inactive;
+        }
+
+        /// <summary>
+        /// Update the activation state of this <see cref="DrawableNote"/>
+        /// </summary>
+        /// <param name="e"></param>
+        protected virtual void UpdateActivationState(ValueChangedEvent<NoteActivationState> e)
+        {
+            switch (e.NewValue)
+            {
+                case NoteActivationState.Active:
+                    this.FadeIn(75, Easing.InBounce);
+                    break;
+
+                case NoteActivationState.Inactive:
+                case NoteActivationState.Judged:
+                    this.FadeOut(50, Easing.OutBounce);
+                    Expire();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Update the note position based on the elapsed time.
+        /// </summary>
+        protected virtual void UpdatePosition()
+        {
+            double speed = MathUtils.EuclideanDistance(
+                NoteLaneExtension.GetSpawnerPosition(Lane),
+                NoteLaneExtension.GetSensorPosition(Lane)) / Playfield.TIME_NOTE_APPEARS;
+
+
+            Position = new Vector2(
+                (float)(Position.X +
+                        ((float)(speed *
+                                 (-(float)Math.Cos(
+                                     (NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) *
+                         Clock.ElapsedFrameTime)),
+                (float)(Position.Y +
+                        ((float)(speed *
+                                 (-(float)Math.Sin(
+                                     (NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) *
+                         Clock.ElapsedFrameTime))
+            );
+        }
+    }
+
+    /// <summary>
+    /// Represent the state
+    /// </summary>
+    public enum NoteActivationState
+    {
+        Inactive, // Not active yet / not active anymore
+        Active,
+        Judged, // Judged, not active anymore
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableNote.cs
@@ -15,6 +15,9 @@ namespace maisim.Game.Component.Gameplay.Notes
     /// </summary>
     public abstract class DrawableNote : CompositeDrawable
     {
+        public readonly double FADE_IN_TIME = 75f;
+        public readonly double FADE_OUT_TIME = 50f;
+
         public NoteLane Lane { get; set; }
 
         protected readonly Bindable<NoteActivationState> State = new Bindable<NoteActivationState>();
@@ -61,10 +64,14 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
             base.Update();
 
+            // Start spawning animation but not update its position.
+            if (Clock.TimeInfo.Current >= TargetTime - Playfield.TIME_NOTE_APPEARS - FADE_IN_TIME && State.Value == NoteActivationState.Inactive)
+                State.Value = NoteActivationState.Spawning;
+
             // note active state should become Active when the clock time reaches near the target time
-            if (Clock.TimeInfo.Current >= TargetTime - Playfield.TIME_NOTE_APPEARS && State.Value == NoteActivationState.Inactive)
+            if (Clock.TimeInfo.Current >= TargetTime - Playfield.TIME_NOTE_APPEARS && State.Value == NoteActivationState.Spawning)
                 State.Value = NoteActivationState.Active;
-            
+
             if (State.Value == NoteActivationState.Active)
                 UpdatePosition();
 
@@ -80,8 +87,8 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
             switch (e.NewValue)
             {
-                case NoteActivationState.Active:
-                    this.FadeIn(75, Easing.InBounce);
+                case NoteActivationState.Spawning:
+                    this.FadeIn(FADE_IN_TIME, Easing.InBounce);
                     break;
 
                 case NoteActivationState.Inactive:
@@ -123,6 +130,7 @@ namespace maisim.Game.Component.Gameplay.Notes
     public enum NoteActivationState
     {
         Inactive, // Not active yet / not active anymore
+        Spawning,
         Active,
         Judged, // Judged, not active anymore
     }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlidePathNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlidePathNote.cs
@@ -31,5 +31,10 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
 
         }
+
+        public override bool CanDespawn()
+        {
+            return false;
+        }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlidePathNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlidePathNote.cs
@@ -32,9 +32,6 @@ namespace maisim.Game.Component.Gameplay.Notes
 
         }
 
-        public override bool CanDespawn()
-        {
-            return false;
-        }
+        public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlidePathNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlidePathNote.cs
@@ -27,11 +27,6 @@ namespace maisim.Game.Component.Gameplay.Notes
             };
         }
 
-        public override void UpdatePosition(Playfield playfield)
-        {
-
-        }
-
         public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlidePathNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlidePathNote.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Graphics;
+﻿using maisim.Game.Screen.Gameplay;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osuTK;
@@ -24,6 +25,11 @@ namespace maisim.Game.Component.Gameplay.Notes
                     Texture = textureStore.Get("Notes/SlidePath.png")
                 }
             };
+        }
+
+        public override void UpdatePosition(Playfield playfield)
+        {
+
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlideStarNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlideStarNote.cs
@@ -25,11 +25,6 @@ namespace maisim.Game.Component.Gameplay.Notes
             };
         }
 
-        public override void UpdatePosition(Playfield playfield)
-        {
-
-        }
-
         public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlideStarNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlideStarNote.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Graphics;
+﻿using maisim.Game.Screen.Gameplay;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 
@@ -22,6 +23,11 @@ namespace maisim.Game.Component.Gameplay.Notes
                     Texture = textureStore.Get("Notes/SlideStar.png")
                 }
             };
+        }
+
+        public override void UpdatePosition(Playfield playfield)
+        {
+
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlideStarNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlideStarNote.cs
@@ -30,9 +30,6 @@ namespace maisim.Game.Component.Gameplay.Notes
 
         }
 
-        public override bool CanDespawn()
-        {
-            return false;
-        }
+        public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlideStarNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableSlideStarNote.cs
@@ -29,5 +29,10 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
 
         }
+
+        public override bool CanDespawn()
+        {
+            return false;
+        }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapBothNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapBothNote.cs
@@ -25,11 +25,6 @@ namespace maisim.Game.Component.Gameplay.Notes
             };
         }
 
-        public override void UpdatePosition(Playfield playfield)
-        {
-
-        }
-
         public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapBothNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapBothNote.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Graphics;
+﻿using maisim.Game.Screen.Gameplay;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 
@@ -22,6 +23,11 @@ namespace maisim.Game.Component.Gameplay.Notes
                     Texture = textureStore.Get("Notes/TapBoth.png")
                 }
             };
+        }
+
+        public override void UpdatePosition(Playfield playfield)
+        {
+
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapBothNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapBothNote.cs
@@ -30,9 +30,6 @@ namespace maisim.Game.Component.Gameplay.Notes
 
         }
 
-        public override bool CanDespawn()
-        {
-            return false;
-        }
+        public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapBothNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapBothNote.cs
@@ -29,5 +29,10 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
 
         }
+
+        public override bool CanDespawn()
+        {
+            return false;
+        }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using maisim.Game.Screen.Gameplay;
+using maisim.Game.Utils;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -37,6 +38,42 @@ namespace maisim.Game.Component.Gameplay.Notes
                     Texture = textureStore.Get("Notes/TapNormal.png")
                 }
             };
+        }
+
+        public override void UpdatePosition(Playfield playfield)
+        {
+            if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(Lane), NoteLaneExtension.GetSensorPosition(Lane)) + Playfield.DISTANCE_ON_DESPAWN <
+                MathUtils.EuclideanDistance(Position, NoteLaneExtension.GetSpawnerPosition(Lane)))
+            {
+                // Enter despawning state
+                this.FadeOut(50, Easing.InBounce);
+                Scheduler.AddDelayed(() => RemoveInternal(this), 500);
+            }
+            else
+            {
+                if (TargetTime != 0f)
+                {
+                    // Update the position
+                    double speed = MathUtils.EuclideanDistance(
+                        NoteLaneExtension.GetSpawnerPosition(Lane),
+                        NoteLaneExtension.GetSensorPosition(Lane)) / Playfield.TIME_NOTE_APPEARS;
+                    Position = new Vector2(
+                        (float) (Position.X + ((float)(speed * (-(float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) * playfield.Clock.ElapsedFrameTime)),
+                        (float) (Position.Y + ((float)(speed * (-(float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) * playfield.Clock.ElapsedFrameTime))
+                        );
+                }
+                else
+                {
+                    // This is for the note that spawn using SpawnTapNote method and no TargetTime specified in the test scene.
+                    // Will remove it when the note spawn system is complete.
+                    Position += new Vector2(
+                        -(Playfield.NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) *
+                                                       (float)(Math.PI / 180))),
+                        -(Playfield.NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) *
+                                                       (float)(Math.PI / 180)))
+                    );
+                }
+            }
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
@@ -42,38 +42,40 @@ namespace maisim.Game.Component.Gameplay.Notes
 
         public override void UpdatePosition(Playfield playfield)
         {
+            if (TargetTime != 0f)
+            {
+                // Update the position
+                double speed = MathUtils.EuclideanDistance(
+                    NoteLaneExtension.GetSpawnerPosition(Lane),
+                    NoteLaneExtension.GetSensorPosition(Lane)) / Playfield.TIME_NOTE_APPEARS;
+                Position = new Vector2(
+                    (float) (Position.X + ((float)(speed * (-(float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) * playfield.Clock.ElapsedFrameTime)),
+                    (float) (Position.Y + ((float)(speed * (-(float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) * playfield.Clock.ElapsedFrameTime))
+                    );
+            }
+            else
+            {
+                // This is for the note that spawn using SpawnTapNote method and no TargetTime specified in the test scene.
+                // Will remove it when the note spawn system is complete.
+                Position += new Vector2(
+                    -(Playfield.NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) *
+                                                   (float)(Math.PI / 180))),
+                    -(Playfield.NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) *
+                                                   (float)(Math.PI / 180)))
+                );
+            }
+        }
+
+        public override bool CanDespawn()
+        {
             if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(Lane), NoteLaneExtension.GetSensorPosition(Lane)) + Playfield.DISTANCE_ON_DESPAWN <
                 MathUtils.EuclideanDistance(Position, NoteLaneExtension.GetSpawnerPosition(Lane)))
             {
                 // Enter despawning state
                 this.FadeOut(50, Easing.InBounce);
-                Scheduler.AddDelayed(() => RemoveInternal(this), 500);
+                return true;
             }
-            else
-            {
-                if (TargetTime != 0f)
-                {
-                    // Update the position
-                    double speed = MathUtils.EuclideanDistance(
-                        NoteLaneExtension.GetSpawnerPosition(Lane),
-                        NoteLaneExtension.GetSensorPosition(Lane)) / Playfield.TIME_NOTE_APPEARS;
-                    Position = new Vector2(
-                        (float) (Position.X + ((float)(speed * (-(float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) * playfield.Clock.ElapsedFrameTime)),
-                        (float) (Position.Y + ((float)(speed * (-(float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) * playfield.Clock.ElapsedFrameTime))
-                        );
-                }
-                else
-                {
-                    // This is for the note that spawn using SpawnTapNote method and no TargetTime specified in the test scene.
-                    // Will remove it when the note spawn system is complete.
-                    Position += new Vector2(
-                        -(Playfield.NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) *
-                                                       (float)(Math.PI / 180))),
-                        -(Playfield.NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) *
-                                                       (float)(Math.PI / 180)))
-                    );
-                }
-            }
+            return false;
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
@@ -22,6 +22,12 @@ namespace maisim.Game.Component.Gameplay.Notes
             Origin = Anchor.Centre;
             Scale = new Vector2(1.2f);
             Margin = new MarginPadding(10);
+            Position = new Vector2(
+                -(Playfield.SPAWNER_MULTIPLIER *
+                  (float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180))),
+                -(Playfield.SPAWNER_MULTIPLIER *
+                  (float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))
+            );
         }
 
         protected override Drawable[] AddNoteParts(TextureStore textureStore)

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
@@ -1,6 +1,10 @@
-﻿using osu.Framework.Graphics;
+﻿using System;
+using maisim.Game.Screen.Gameplay;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osuTK;
 
 namespace maisim.Game.Component.Gameplay.Notes
 {
@@ -9,8 +13,22 @@ namespace maisim.Game.Component.Gameplay.Notes
     /// </summary>
     public class DrawableTapNote : DrawableNote
     {
-
         public NoteLane Lane { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Position = new Vector2(
+                -(Playfield.SPAWNER_MULTIPLIER *
+                  (float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180))),
+                -(Playfield.SPAWNER_MULTIPLIER *
+                  (float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))
+            );
+            Scale = new Vector2(1.2f);
+            Margin = new MarginPadding(10);
+        }
 
         protected override Drawable[] AddNoteParts(TextureStore textureStore)
         {

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
@@ -49,9 +49,17 @@ namespace maisim.Game.Component.Gameplay.Notes
                     NoteLaneExtension.GetSpawnerPosition(Lane),
                     NoteLaneExtension.GetSensorPosition(Lane)) / Playfield.TIME_NOTE_APPEARS;
                 Position = new Vector2(
-                    (float) (Position.X + ((float)(speed * (-(float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) * playfield.Clock.ElapsedFrameTime)),
-                    (float) (Position.Y + ((float)(speed * (-(float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) * playfield.Clock.ElapsedFrameTime))
-                    );
+                    (float)(Position.X +
+                            ((float)(speed *
+                                     (-(float)Math.Cos(
+                                         (NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) *
+                             playfield.Clock.ElapsedFrameTime)),
+                    (float)(Position.Y +
+                            ((float)(speed *
+                                     (-(float)Math.Sin(
+                                         (NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) *
+                             playfield.Clock.ElapsedFrameTime))
+                );
             }
             else
             {
@@ -59,23 +67,29 @@ namespace maisim.Game.Component.Gameplay.Notes
                 // Will remove it when the note spawn system is complete.
                 Position += new Vector2(
                     -(Playfield.NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) *
-                                                   (float)(Math.PI / 180))),
+                                                             (float)(Math.PI / 180))),
                     -(Playfield.NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) *
-                                                   (float)(Math.PI / 180)))
+                                                             (float)(Math.PI / 180)))
                 );
             }
         }
 
-        public override bool CanDespawn()
+        public override bool CanDespawn
         {
-            if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(Lane), NoteLaneExtension.GetSensorPosition(Lane)) + Playfield.DISTANCE_ON_DESPAWN <
-                MathUtils.EuclideanDistance(Position, NoteLaneExtension.GetSpawnerPosition(Lane)))
+            get
             {
-                // Enter despawning state
-                this.FadeOut(50, Easing.InBounce);
-                return true;
+                if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(Lane),
+                        NoteLaneExtension.GetSensorPosition(Lane)) + Playfield.DISTANCE_ON_DESPAWN <
+                    MathUtils.EuclideanDistance(Position, NoteLaneExtension.GetSpawnerPosition(Lane)))
+                {
+                    // Enter despawning state
+                    this.FadeOut(50, Easing.InBounce);
+                    return true;
+                }
+
+                return false;
             }
-            return false;
         }
+
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
@@ -20,12 +20,6 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            Position = new Vector2(
-                -(Playfield.SPAWNER_MULTIPLIER *
-                  (float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180))),
-                -(Playfield.SPAWNER_MULTIPLIER *
-                  (float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))
-            );
             Scale = new Vector2(1.2f);
             Margin = new MarginPadding(10);
         }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTapNote.cs
@@ -14,7 +14,6 @@ namespace maisim.Game.Component.Gameplay.Notes
     /// </summary>
     public class DrawableTapNote : DrawableNote
     {
-        public NoteLane Lane { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -40,56 +39,7 @@ namespace maisim.Game.Component.Gameplay.Notes
             };
         }
 
-        public override void UpdatePosition(Playfield playfield)
-        {
-            if (TargetTime != 0f)
-            {
-                // Update the position
-                double speed = MathUtils.EuclideanDistance(
-                    NoteLaneExtension.GetSpawnerPosition(Lane),
-                    NoteLaneExtension.GetSensorPosition(Lane)) / Playfield.TIME_NOTE_APPEARS;
-                Position = new Vector2(
-                    (float)(Position.X +
-                            ((float)(speed *
-                                     (-(float)Math.Cos(
-                                         (NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) *
-                             playfield.Clock.ElapsedFrameTime)),
-                    (float)(Position.Y +
-                            ((float)(speed *
-                                     (-(float)Math.Sin(
-                                         (NoteLaneExtension.GetAngle(Lane) + 90f) * (float)(Math.PI / 180)))) *
-                             playfield.Clock.ElapsedFrameTime))
-                );
-            }
-            else
-            {
-                // This is for the note that spawn using SpawnTapNote method and no TargetTime specified in the test scene.
-                // Will remove it when the note spawn system is complete.
-                Position += new Vector2(
-                    -(Playfield.NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(Lane) + 90f) *
-                                                             (float)(Math.PI / 180))),
-                    -(Playfield.NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(Lane) + 90f) *
-                                                             (float)(Math.PI / 180)))
-                );
-            }
-        }
-
-        public override bool CanDespawn
-        {
-            get
-            {
-                if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(Lane),
-                        NoteLaneExtension.GetSensorPosition(Lane)) + Playfield.DISTANCE_ON_DESPAWN <
-                    MathUtils.EuclideanDistance(Position, NoteLaneExtension.GetSpawnerPosition(Lane)))
-                {
-                    // Enter despawning state
-                    this.FadeOut(50, Easing.InBounce);
-                    return true;
-                }
-
-                return false;
-            }
-        }
-
+        public override bool CanDespawn => MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(Lane), NoteLaneExtension.GetSensorPosition(Lane)) + Playfield.DISTANCE_ON_DESPAWN < MathUtils.EuclideanDistance(Position, NoteLaneExtension.GetSpawnerPosition(Lane));
     }
+
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchHoldNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchHoldNote.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Graphics;
+﻿using maisim.Game.Screen.Gameplay;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 
@@ -22,6 +23,11 @@ namespace maisim.Game.Component.Gameplay.Notes
                     Texture = textureStore.Get("Notes/TouchHold.png")
                 }
             };
+        }
+
+        public override void UpdatePosition(Playfield playfield)
+        {
+
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchHoldNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchHoldNote.cs
@@ -25,11 +25,6 @@ namespace maisim.Game.Component.Gameplay.Notes
             };
         }
 
-        public override void UpdatePosition(Playfield playfield)
-        {
-
-        }
-
         public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchHoldNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchHoldNote.cs
@@ -30,9 +30,6 @@ namespace maisim.Game.Component.Gameplay.Notes
 
         }
 
-        public override bool CanDespawn()
-        {
-            return false;
-        }
+        public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchHoldNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchHoldNote.cs
@@ -29,5 +29,10 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
 
         }
+
+        public override bool CanDespawn()
+        {
+            return false;
+        }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchNote.cs
@@ -71,9 +71,6 @@ namespace maisim.Game.Component.Gameplay.Notes
 
         }
 
-        public override bool CanDespawn()
-        {
-            return false;
-        }
+        public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchNote.cs
@@ -70,5 +70,10 @@ namespace maisim.Game.Component.Gameplay.Notes
         {
 
         }
+
+        public override bool CanDespawn()
+        {
+            return false;
+        }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchNote.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Graphics;
+﻿using maisim.Game.Screen.Gameplay;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osuTK;
@@ -63,6 +64,11 @@ namespace maisim.Game.Component.Gameplay.Notes
                     Texture = textureStore.Get("Notes/TouchArrow.png")
                 }
             };
+        }
+
+        public override void UpdatePosition(Playfield playfield)
+        {
+
         }
     }
 }

--- a/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchNote.cs
+++ b/maisim/maisim.Game/Component/Gameplay/Notes/DrawableTouchNote.cs
@@ -66,11 +66,6 @@ namespace maisim.Game.Component.Gameplay.Notes
             };
         }
 
-        public override void UpdatePosition(Playfield playfield)
-        {
-
-        }
-
         public override bool CanDespawn => false;
     }
 }

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -22,6 +22,9 @@ namespace maisim.Game.Screen.Gameplay
 
         public const float DISTANCE_ON_DESPAWN = 40f;
 
+        /// <summary>
+        /// The time that note need to be spawn before the note's target time.
+        /// </summary>
         public const float TIME_NOTE_APPEARS = 500f;
 
         public List<DrawableNote> NotesPool;

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using maisim.Game.Component.Gameplay.Notes;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osuTK;
 
 namespace maisim.Game.Screen.Gameplay
@@ -11,7 +12,7 @@ namespace maisim.Game.Screen.Gameplay
     /// <summary>
     /// A main playfield that contains all the notes and manages their rendering.
     /// </summary>
-    public class Playfield : osu.Framework.Screens.Screen
+    public class Playfield : Container
     {
         public const float SPAWNER_MULTIPLIER = 75f;
 
@@ -29,7 +30,7 @@ namespace maisim.Game.Screen.Gameplay
         [BackgroundDependencyLoader]
         private void load()
         {
-
+            RelativeSizeAxes = Axes.Both;
         }
 
         /// <summary>
@@ -85,14 +86,6 @@ namespace maisim.Game.Screen.Gameplay
 
         protected override void Update()
         {
-            // Add note from the pool to the playfield drawable
-            if (NotesPool != null)
-            {
-                foreach (DrawableNote note in NotesPool.ToList())
-                {
-                    spawnNoteFromPool(note);
-                }
-            }
 
             // Update the position of the notes
             foreach (Drawable note in InternalChildren.ToList())

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -65,7 +65,6 @@ namespace maisim.Game.Screen.Gameplay
                         if (tapNote.TargetTime != 0f && Clock.TimeInfo.Current >= tapNote.TargetTime - TIME_NOTE_APPEARS)
                         {
                             AddInternal(note);
-                            Logger.Log($"Note spawn at {Clock.TimeInfo.Current}", LoggingTarget.Runtime, LogLevel.Debug);
                             NotesPool.Remove(tapNote);
                         }
                     }
@@ -82,7 +81,6 @@ namespace maisim.Game.Screen.Gameplay
                         // Enter despawning state
                         note.FadeOut(50, Easing.InBounce);
                         Scheduler.AddDelayed(() => RemoveInternal(note), 500);
-                        Logger.LogPrint("Despawned at " + Clock.TimeInfo.Current);
                     }
                     else
                     {

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -49,12 +49,6 @@ namespace maisim.Game.Screen.Gameplay
         {
             Add(new DrawableTapNote
             {
-                Position = new Vector2(
-                    -(SPAWNER_MULTIPLIER *
-                      (float)Math.Cos((NoteLaneExtension.GetAngle(lane) + 90f) * (float)(Math.PI / 180))),
-                    -(SPAWNER_MULTIPLIER *
-                      (float)Math.Sin((NoteLaneExtension.GetAngle(lane) + 90f) * (float)(Math.PI / 180)))
-                ),
                 Lane = lane,
                 TargetTime = Clock.CurrentTime + TIME_NOTE_APPEARS + 1
             });

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -52,6 +52,12 @@ namespace maisim.Game.Screen.Gameplay
         {
             AddInternal(new DrawableTapNote
             {
+                Position = new Vector2(
+                    -(SPAWNER_MULTIPLIER *
+                      (float)Math.Cos((NoteLaneExtension.GetAngle(lane) + 90f) * (float)(Math.PI / 180))),
+                    -(SPAWNER_MULTIPLIER *
+                      (float)Math.Sin((NoteLaneExtension.GetAngle(lane) + 90f) * (float)(Math.PI / 180)))
+                ),
                 Lane = lane
             });
         }
@@ -67,6 +73,12 @@ namespace maisim.Game.Screen.Gameplay
                     {
                         if (tapNote.TargetTime != 0f && Clock.TimeInfo.Current >= tapNote.TargetTime - TIME_NOTE_APPEARS)
                         {
+                            note.Position = new Vector2(
+                                -(SPAWNER_MULTIPLIER *
+                                  (float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180))),
+                                -(SPAWNER_MULTIPLIER *
+                                  (float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))
+                            );
                             AddInternal(note);
                             NotesPool.Remove(tapNote);
                         }

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using maisim.Game.Component.Gameplay.Notes;
-using maisim.Game.Utils;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Logging;
 using osuTK;
 
 namespace maisim.Game.Screen.Gameplay
@@ -63,46 +60,6 @@ namespace maisim.Game.Screen.Gameplay
         }
 
         /// <summary>
-        /// Update the target <see cref="DrawableNote"/>'s position.
-        /// </summary>
-        /// <param name="tapNote">The <see cref="DrawableTapNote"/> that want to update.</param>
-        private void updateTapNotePosition(DrawableTapNote tapNote)
-        {
-            if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(tapNote.Lane), NoteLaneExtension.GetSensorPosition(tapNote.Lane)) + DISTANCE_ON_DESPAWN <
-                MathUtils.EuclideanDistance(tapNote.Position, NoteLaneExtension.GetSpawnerPosition(tapNote.Lane)))
-            {
-                // Enter despawning state
-                tapNote.FadeOut(50, Easing.InBounce);
-                Scheduler.AddDelayed(() => RemoveInternal(tapNote), 500);
-            }
-            else
-            {
-                if (tapNote.TargetTime != 0f)
-                {
-                    // Update the position
-                    double speed = MathUtils.EuclideanDistance(
-                        NoteLaneExtension.GetSpawnerPosition(tapNote.Lane),
-                        NoteLaneExtension.GetSensorPosition(tapNote.Lane)) / TIME_NOTE_APPEARS;
-                    tapNote.Position = new Vector2(
-                        (float) (tapNote.Position.X + ((float)(speed * (-(float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))) * Clock.ElapsedFrameTime)),
-                        (float) (tapNote.Position.Y + ((float)(speed * (-(float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))) * Clock.ElapsedFrameTime))
-                        );
-                }
-                else
-                {
-                    // This is for the note that spawn using SpawnTapNote method and no TargetTime specified in the test scene.
-                    // Will remove it when the note spawn system is complete.
-                    tapNote.Position += new Vector2(
-                        -(NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) *
-                                                       (float)(Math.PI / 180))),
-                        -(NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) *
-                                                       (float)(Math.PI / 180)))
-                    );
-                }
-            }
-        }
-
-        /// <summary>
         /// Spawn the note from the pool to the playfield and remove it from the pool.
         /// </summary>
         /// <param name="note">The target note</param>
@@ -140,9 +97,9 @@ namespace maisim.Game.Screen.Gameplay
             // Update the position of the notes
             foreach (Drawable note in InternalChildren.ToList())
             {
-                if (note is DrawableTapNote tapNote)
+                if (note is DrawableNote drawableNote)
                 {
-                    updateTapNotePosition(tapNote);
+                    drawableNote.UpdatePosition(this);
                 }
             }
 

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using maisim.Game.Component.Gameplay.Notes;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -39,7 +38,7 @@ namespace maisim.Game.Screen.Gameplay
         /// <param name="note">A desired <see cref="DrawableNote"/>.</param>
         public void SpawnNote(DrawableNote note)
         {
-            AddInternal(note);
+            Add(note);
         }
 
         /// <summary>
@@ -48,7 +47,7 @@ namespace maisim.Game.Screen.Gameplay
         /// <param name="lane">The <see cref="NoteLane"/> that the <see cref="DrawableTapNote"/> want to spawn.</param>
         public void SpawnTapNote(NoteLane lane)
         {
-            AddInternal(new DrawableTapNote
+            Add(new DrawableTapNote
             {
                 Position = new Vector2(
                     -(SPAWNER_MULTIPLIER *
@@ -56,54 +55,10 @@ namespace maisim.Game.Screen.Gameplay
                     -(SPAWNER_MULTIPLIER *
                       (float)Math.Sin((NoteLaneExtension.GetAngle(lane) + 90f) * (float)(Math.PI / 180)))
                 ),
-                Lane = lane
+                Lane = lane,
+                TargetTime = Clock.CurrentTime + TIME_NOTE_APPEARS + 1
             });
         }
 
-        /// <summary>
-        /// Spawn the note from the pool to the playfield and remove it from the pool.
-        /// </summary>
-        /// <param name="note">The target note</param>
-        private void spawnNoteFromPool(DrawableNote note)
-        {
-            // We have a lot of note type so we need to check on its type before we can update it
-            if (note is DrawableTapNote tapNote)
-            {
-                if (tapNote.TargetTime != 0f && Clock.TimeInfo.Current >= tapNote.TargetTime - TIME_NOTE_APPEARS)
-                {
-                    // Add note to the drawable and remove it from the pool
-                    note.Position = new Vector2(
-                        -(SPAWNER_MULTIPLIER *
-                          (float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180))),
-                        -(SPAWNER_MULTIPLIER *
-                          (float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))
-                    );
-                    AddInternal(note);
-                    NotesPool.Remove(tapNote);
-                }
-            }
-        }
-
-        protected override void Update()
-        {
-
-            // Update the position of the notes
-            foreach (Drawable note in InternalChildren.ToList())
-            {
-                if (note is DrawableNote drawableNote)
-                {
-                    if (drawableNote.CanDespawn)
-                    {
-                        Scheduler.AddDelayed(() => RemoveInternal(drawableNote), 500);
-                    }
-                    else
-                    {
-                        drawableNote.UpdatePosition(this);
-                    }
-                }
-            }
-
-            base.Update();
-        }
     }
 }

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -99,7 +99,14 @@ namespace maisim.Game.Screen.Gameplay
             {
                 if (note is DrawableNote drawableNote)
                 {
-                    drawableNote.UpdatePosition(this);
+                    if (drawableNote.CanDespawn())
+                    {
+                        Scheduler.AddDelayed(() => RemoveInternal(drawableNote), 500);
+                    }
+                    else
+                    {
+                        drawableNote.UpdatePosition(this);
+                    }
                 }
             }
 

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -50,7 +50,7 @@ namespace maisim.Game.Screen.Gameplay
             Add(new DrawableTapNote
             {
                 Lane = lane,
-                TargetTime = Clock.CurrentTime + TIME_NOTE_APPEARS + 1
+                TargetTime = Clock.CurrentTime + TIME_NOTE_APPEARS + 100
             });
         }
 

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -92,7 +92,7 @@ namespace maisim.Game.Screen.Gameplay
             {
                 if (note is DrawableNote drawableNote)
                 {
-                    if (drawableNote.CanDespawn())
+                    if (drawableNote.CanDespawn)
                     {
                         Scheduler.AddDelayed(() => RemoveInternal(drawableNote), 500);
                     }

--- a/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/Playfield.cs
@@ -62,6 +62,44 @@ namespace maisim.Game.Screen.Gameplay
             });
         }
 
+        /// <summary>
+        /// Update the target <see cref="DrawableNote"/>'s position.
+        /// </summary>
+        /// <param name="tapNote">The <see cref="DrawableTapNote"/> that want to update.</param>
+        private void updateTapNotePosition(DrawableTapNote tapNote)
+        {
+            if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(tapNote.Lane), NoteLaneExtension.GetSensorPosition(tapNote.Lane)) + DISTANCE_ON_DESPAWN <
+                MathUtils.EuclideanDistance(tapNote.Position, NoteLaneExtension.GetSpawnerPosition(tapNote.Lane)))
+            {
+                // Enter despawning state
+                tapNote.FadeOut(50, Easing.InBounce);
+                Scheduler.AddDelayed(() => RemoveInternal(tapNote), 500);
+            }
+            else
+            {
+                if (tapNote.TargetTime != 0f)
+                {
+                    double speed = MathUtils.EuclideanDistance(
+                        NoteLaneExtension.GetSpawnerPosition(tapNote.Lane),
+                        NoteLaneExtension.GetSensorPosition(tapNote.Lane)) / TIME_NOTE_APPEARS;
+                    tapNote.Position = new Vector2(
+                        (float) (tapNote.Position.X + ((float)(speed * (-(float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))) * Clock.ElapsedFrameTime)),
+                        (float) (tapNote.Position.Y + ((float)(speed * (-(float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))) * Clock.ElapsedFrameTime))
+                        );
+                }
+                else
+                {
+                    // Update the position
+                    tapNote.Position += new Vector2(
+                        -(NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) *
+                                                       (float)(Math.PI / 180))),
+                        -(NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) *
+                                                       (float)(Math.PI / 180)))
+                    );
+                }
+            }
+        }
+
         protected override void Update()
         {
             if (NotesPool != null)
@@ -90,36 +128,7 @@ namespace maisim.Game.Screen.Gameplay
             {
                 if (note is DrawableTapNote tapNote)
                 {
-                    if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(tapNote.Lane), NoteLaneExtension.GetSensorPosition(tapNote.Lane)) + DISTANCE_ON_DESPAWN <
-                        MathUtils.EuclideanDistance(tapNote.Position, NoteLaneExtension.GetSpawnerPosition(tapNote.Lane)))
-                    {
-                        // Enter despawning state
-                        note.FadeOut(50, Easing.InBounce);
-                        Scheduler.AddDelayed(() => RemoveInternal(note), 500);
-                    }
-                    else
-                    {
-                        if (tapNote.TargetTime != 0f)
-                        {
-                            double speed = MathUtils.EuclideanDistance(
-                                NoteLaneExtension.GetSpawnerPosition(tapNote.Lane),
-                                NoteLaneExtension.GetSensorPosition(tapNote.Lane)) / TIME_NOTE_APPEARS;
-                            tapNote.Position = new Vector2(
-                                (float) (tapNote.Position.X + ((float)(speed * (-(float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))) * Clock.ElapsedFrameTime)),
-                                (float) (tapNote.Position.Y + ((float)(speed * (-(float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))) * Clock.ElapsedFrameTime))
-                                );
-                        }
-                        else
-                        {
-                            // Update the position
-                            note.Position += new Vector2(
-                                -(NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) *
-                                                               (float)(Math.PI / 180))),
-                                -(NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) *
-                                                               (float)(Math.PI / 180)))
-                            );
-                        }
-                    }
+                    updateTapNotePosition(tapNote);
                 }
             }
 

--- a/maisim/maisim.Game/Screen/Gameplay/PlayfieldScreen.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/PlayfieldScreen.cs
@@ -16,6 +16,11 @@ namespace maisim.Game.Screen.Gameplay
         /// </summary>
         public Playfield Playfield { get; set; }
 
+        public PlayfieldScreen()
+        {
+            Playfield = new Playfield();
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -32,7 +37,6 @@ namespace maisim.Game.Screen.Gameplay
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
-                Playfield = new Playfield()
             };
         }
     }

--- a/maisim/maisim.Game/Screen/Gameplay/PlayfieldScreen.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/PlayfieldScreen.cs
@@ -16,11 +16,6 @@ namespace maisim.Game.Screen.Gameplay
         /// </summary>
         public Playfield Playfield { get; set; }
 
-        public PlayfieldScreen()
-        {
-            Playfield = new Playfield();
-        }
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -37,6 +32,7 @@ namespace maisim.Game.Screen.Gameplay
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
+                Playfield = new Playfield()
             };
         }
     }

--- a/maisim/maisim.Game/Screen/Gameplay/PlayfieldScreen.cs
+++ b/maisim/maisim.Game/Screen/Gameplay/PlayfieldScreen.cs
@@ -16,6 +16,11 @@ namespace maisim.Game.Screen.Gameplay
         /// </summary>
         public Playfield Playfield { get; set; }
 
+        public PlayfieldScreen()
+        {
+            Playfield = new Playfield();
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -32,7 +37,7 @@ namespace maisim.Game.Screen.Gameplay
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
-                Playfield = new Playfield()
+                Playfield
             };
         }
     }


### PR DESCRIPTION
Currently when the note spawn we need to launch the method `SpawnNote` or `SpawnTapNote` in `Playfield` but this PR add a new `Playfield` ability to make `Playfield` can correctly spawn a note at the correct time.

- Now `DrawableNote` has a property call `TargetTime` to collect the time that the note need to be hit or get to the goal.
- In `Playfield` I add a new list call `NotesPool` for the future use too. And if you need to spawn using target time you need to put your note in this list too to make a thing work.
- The old logic are not gone but the old logic use `SPEED` as a note velocity but in the new logic I set the `TIME_NOTE_APPEARS` so the note need to spawn in `note.TargetTime - TIME_NOTE_APPEARS` and must reach in time.

# Testing

This PRs is somehow hard to test on how accurate is this thing work but you can test it by add some `LogPrint` to the note spawn and despawn logic in `Playfield`

```csharp
protected override void Update()
{
    if (NotesPool != null)
    {
        foreach (Drawable note in NotesPool.ToList())
        {
            // We have a lot of note type so we need to check on its type before we can update it
            if (note is DrawableTapNote tapNote)
            {
                if (tapNote.TargetTime != 0f && Clock.TimeInfo.Current >= tapNote.TargetTime - TIME_NOTE_APPEARS)
                {
                    AddInternal(note);
                    Logger.LogPrint("Note spawn at " + Clock.TimeInfo.Current); // Spawn logging
                    NotesPool.Remove(tapNote);
                }
            }
        }
    }

    foreach (Drawable note in InternalChildren.ToList())
    {
        if (note is DrawableTapNote tapNote)
        {
            if (MathUtils.EuclideanDistance(NoteLaneExtension.GetSpawnerPosition(tapNote.Lane), NoteLaneExtension.GetSensorPosition(tapNote.Lane)) <
                MathUtils.EuclideanDistance(tapNote.Position, NoteLaneExtension.GetSpawnerPosition(tapNote.Lane)))
            {
                // Enter despawning state
                note.FadeOut(50, Easing.InBounce);
                Scheduler.AddDelayed(() => RemoveInternal(note), 500);
                Logger.LogPrint("Despawned at " + Clock.TimeInfo.Current); // Despawn logging
                // Don't forget to remove DISTANCE_ON_DESPAWN before test!
            }
            else
            {
                if (tapNote.TargetTime != 0f)
                {
                    double speed = MathUtils.EuclideanDistance(
                        NoteLaneExtension.GetSpawnerPosition(tapNote.Lane),
                        NoteLaneExtension.GetSensorPosition(tapNote.Lane)) / TIME_NOTE_APPEARS;
                    tapNote.Position = new Vector2(
                        (float) (tapNote.Position.X + ((float)(speed * (-(float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))) * Clock.ElapsedFrameTime)),
                        (float) (tapNote.Position.Y + ((float)(speed * (-(float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) * (float)(Math.PI / 180)))) * Clock.ElapsedFrameTime))
                        );
                }
                else
                {
                    // Update the position
                    note.Position += new Vector2(
                        -(NOTE_SPEED * (float)Math.Cos((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) *
                                                       (float)(Math.PI / 180))),
                        -(NOTE_SPEED * (float)Math.Sin((NoteLaneExtension.GetAngle(tapNote.Lane) + 90f) *
                                                       (float)(Math.PI / 180)))
                    );
                }
            }
        }
    }

    base.Update();
}
```

The result is very accurate but missing like from 1 ms to max like to 20 when the `ElapsedFrameTime` is high when inactive.

```csharp
// Note set time goal at 5000 ms
// Active
[runtime] 2022-03-25 22:56:48 [verbose]: Note spawn at 4500.8809
[runtime] 2022-03-25 22:56:48 [verbose]: Despawned at 5000.8792

// Inactive
[runtime] 2022-03-25 23:01:09 [verbose]: Note spawn at 4501.634
[runtime] 2022-03-25 23:01:10 [verbose]: Despawned at 5019.570500000001
```

And from this PR with new logic now we can control by slower or faster the time now. (But the note that's spawn with old logic still cannot control the time.)