### PR TITLE
Fix `IScreen` breaking change from last framework update

### DIFF
--- a/maisim/maisim.Game/Screen/MainMenuScreen.cs
+++ b/maisim/maisim.Game/Screen/MainMenuScreen.cs
@@ -74,10 +74,8 @@ namespace maisim.Game.Screen
             };
         }
 
-        public override void OnEntering(IScreen last)
+        public override void OnEntering(ScreenTransitionEvent e)
         {
-            base.OnEntering(last);
-
             this.FadeInFromZero(500);
         }
     }


### PR DESCRIPTION
From [the breaking change](https://github.com/ppy/osu-framework/wiki/Breaking-changes) in last update change `IScreen` navigation to recieve event args instead.