### PR TITLE
Fix hole in condition in `CalculateRank` function

### DIFF
--- a/maisim/maisim.Game/Scores/ScoreProcessor.cs
+++ b/maisim/maisim.Game/Scores/ScoreProcessor.cs
@@ -14,62 +14,62 @@ namespace maisim.Game.Scores
                 return ScoreRank.SSSPlus;
             }
 
-            if (accuracy >= 100 && accuracy <= 100.49f)
+            if (accuracy >= 100)
             {
                 return ScoreRank.SSS;
             }
 
-            if (accuracy >= 99.5f && accuracy <= 99.99f)
+            if (accuracy >= 99.5f)
             {
                 return ScoreRank.SSPlus;
             }
 
-            if (accuracy >= 99 && accuracy <= 99.49f)
+            if (accuracy >= 99)
             {
                 return ScoreRank.SS;
             }
 
-            if (accuracy >= 98 && accuracy <= 98.99f)
+            if (accuracy >= 98)
             {
                 return ScoreRank.SPlus;
             }
 
-            if (accuracy >= 97 && accuracy <= 97.99f)
+            if (accuracy >= 97)
             {
                 return ScoreRank.S;
             }
 
-            if (accuracy >= 94 && accuracy <= 96.99f)
+            if (accuracy >= 94)
             {
                 return ScoreRank.AAA;
             }
 
-            if (accuracy >= 90 && accuracy <= 93.99f)
+            if (accuracy >= 90)
             {
                 return ScoreRank.AA;
             }
 
-            if (accuracy >= 80 && accuracy <= 89.99f)
+            if (accuracy >= 80)
             {
                 return ScoreRank.A;
             }
 
-            if (accuracy >= 75 && accuracy <= 79.99f)
+            if (accuracy >= 75)
             {
                 return ScoreRank.BBB;
             }
 
-            if (accuracy >= 70 && accuracy <= 74.99f)
+            if (accuracy >= 70)
             {
                 return ScoreRank.BB;
             }
 
-            if (accuracy >= 60 && accuracy <= 69.99f)
+            if (accuracy >= 60)
             {
                 return ScoreRank.B;
             }
 
-            if (accuracy >= 50 && accuracy <= 59.99f)
+            if (accuracy >= 50)
             {
                 return ScoreRank.C;
             }

--- a/maisim/maisim.Game/Scores/ScoreProcessor.cs
+++ b/maisim/maisim.Game/Scores/ScoreProcessor.cs
@@ -10,72 +10,45 @@ namespace maisim.Game.Scores
         public static ScoreRank CalculateRank(float accuracy)
         {
             if (accuracy >= 100.5f)
-            {
                 return ScoreRank.SSSPlus;
-            }
 
             if (accuracy >= 100)
-            {
                 return ScoreRank.SSS;
-            }
 
             if (accuracy >= 99.5f)
-            {
                 return ScoreRank.SSPlus;
-            }
 
             if (accuracy >= 99)
-            {
                 return ScoreRank.SS;
-            }
 
             if (accuracy >= 98)
-            {
                 return ScoreRank.SPlus;
-            }
 
             if (accuracy >= 97)
-            {
                 return ScoreRank.S;
-            }
 
             if (accuracy >= 94)
-            {
                 return ScoreRank.AAA;
-            }
 
             if (accuracy >= 90)
-            {
                 return ScoreRank.AA;
-            }
 
             if (accuracy >= 80)
-            {
                 return ScoreRank.A;
-            }
 
             if (accuracy >= 75)
-            {
                 return ScoreRank.BBB;
-            }
 
             if (accuracy >= 70)
-            {
                 return ScoreRank.BB;
-            }
 
             if (accuracy >= 60)
-            {
                 return ScoreRank.B;
-            }
 
             if (accuracy >= 50)
-            {
                 return ScoreRank.C;
-            }
 
             return ScoreRank.D;
-
         }
     }
 }

--- a/maisim/maisim.Game/Scores/ScoreProcessor.cs
+++ b/maisim/maisim.Game/Scores/ScoreProcessor.cs
@@ -74,12 +74,8 @@ namespace maisim.Game.Scores
                 return ScoreRank.C;
             }
 
-            if (accuracy <= 49.99f)
-            {
-                return ScoreRank.D;
-            }
+            return ScoreRank.D;
 
-            throw new ArgumentOutOfRangeException(nameof(accuracy));
         }
     }
 }


### PR DESCRIPTION
## Issue mentioned
[I discussed the cause here.](https://github.com/HelloYeew/maisim/issues/73#issuecomment-1140411156)

## What I have done
I remove `<=` equal in conditions as it will be implicitly checked when `accuracy` does not meet the previous condition. Since the block inside is a single `return` statement, `else if` is redundant so I used `if` instead. 

Also, I remove the condition for rank D because it is a default value when `accuracy` does not meet any condition above. The function will no longer throw `ArgumentOutOfRangeException` because there is a default value (Rank D).