### PR TITLE
Move desktop host name on test project to make it same with desktop

### DIFF
--- a/maisim/maisim.Game.Tests/Program.cs
+++ b/maisim/maisim.Game.Tests/Program.cs
@@ -7,7 +7,7 @@ namespace maisim.Game.Tests
     {
         public static void Main()
         {
-            using (GameHost host = Host.GetSuitableDesktopHost("maisim-test", new HostOptions { BindIPC = true }))
+            using (GameHost host = Host.GetSuitableDesktopHost("maisim", new HostOptions { BindIPC = true }))
             using (var game = new maisimTestBrowser())
                 host.Run(game);
         }


### PR DESCRIPTION
Currently when run the test in `Program.cs` file that's start the test project is using the `maisim-test` host that's seperate from the `maisim` host that's normally run in default desktop project. So in this PR I move the host name in test project to make it use the same data folder as the desktop name. (In o!f it normally read the file in folder name from the host name so currently the test folder app in `%Appdata%` is seperate from the normal desktop folder) This is the first prerequisite for the coming database and custom track that's I implementing.