### PR TITLE
Add all EFCore related package to ignore on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "maisim/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      # Ignore all EFCore update since it's not supported by current .NET version of the project 
+      - dependency-name: "Microsoft.EntityFrameworkCore.Sqlite"
+      - dependency-name: "Microsoft.EntityFrameworkCore.Design"
+      - dependency-name: "Microsoft.EntityFrameworkCore"
+    reviewers:
+      - "HelloYeew"


### PR DESCRIPTION
Since we still using .NET standard and this is the last version of EFCore that's support this .NET so this PR ignore all EFCore related package that we're using. Also add me as reviewer on the dependabot PR to make it as priority on my GitHub notification list.