### PR TITLE
Change window name and display on debug

### DIFF
--- a/maisim/maisim.Desktop/maisimGameDesktop.cs
+++ b/maisim/maisim.Desktop/maisimGameDesktop.cs
@@ -5,6 +5,17 @@ namespace maisim.Desktop
 {
     public class maisimGameDesktop : maisimGame
     {
+        public override void SetHost(GameHost host)
+        {
+            base.SetHost(host);
+            var desktopWindow = (SDL2DesktopWindow)host.Window;
+
+            desktopWindow.Title = "maisim";
+#if DEBUG
+            desktopWindow.Title += " development";
+#endif
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();

--- a/maisim/maisim.Desktop/maisimGameDesktop.cs
+++ b/maisim/maisim.Desktop/maisimGameDesktop.cs
@@ -13,9 +13,8 @@ namespace maisim.Desktop
 
             desktopWindow.Title = "maisim";
             if (DebugUtils.IsDebugBuild)
-            {
                 desktopWindow.Title += " development";
-            }
+                
         }
 
         protected override void LoadComplete()

--- a/maisim/maisim.Desktop/maisimGameDesktop.cs
+++ b/maisim/maisim.Desktop/maisimGameDesktop.cs
@@ -1,4 +1,5 @@
 ﻿using maisim.Game;
+using osu.Framework.Development;
 using osu.Framework.Platform;
 
 namespace maisim.Desktop
@@ -11,9 +12,10 @@ namespace maisim.Desktop
             var desktopWindow = (SDL2DesktopWindow)host.Window;
 
             desktopWindow.Title = "maisim";
-#if DEBUG
-            desktopWindow.Title += " development";
-#endif
+            if (DebugUtils.IsDebugBuild)
+            {
+                desktopWindow.Title += " development";
+            }
         }
 
         protected override void LoadComplete()

--- a/maisim/maisim.Game/Screen/MainMenuScreen.cs
+++ b/maisim/maisim.Game/Screen/MainMenuScreen.cs
@@ -1,12 +1,15 @@
-﻿using maisim.Game.Graphics.Sprites;
+﻿using System;
+using maisim.Game.Graphics.Sprites;
 using maisim.Game.Graphics.UserInterface;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
+using osu.Framework.Development;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osuTK;
 
@@ -104,7 +107,7 @@ namespace maisim.Game.Screen
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
-                    Text = "maisim development build",
+                    Text = DebugUtils.IsDebugBuild ? "maisim development build" : $"maisim v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}",
                     Scale = new Vector2(0)
                 }
             };

--- a/maisim/maisim.Game/Screen/MainMenuScreen.cs
+++ b/maisim/maisim.Game/Screen/MainMenuScreen.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using maisim.Game.Graphics.Sprites;
+﻿using maisim.Game.Graphics.Sprites;
 using maisim.Game.Graphics.UserInterface;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
@@ -9,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osuTK;
 


### PR DESCRIPTION
This PRs change window's name to game name and try to start seperating windows name between debug and release mode by change text in `MainMenuScreen` and make windows name render seperately.