### PR TITLE
Fix button's interaction still enable when click right mouse

### DIFF
--- a/maisim/maisim.Game.Tests/Visual/Component/TestSceneBackButton.cs
+++ b/maisim/maisim.Game.Tests/Visual/Component/TestSceneBackButton.cs
@@ -1,4 +1,4 @@
-using maisim.Game.Component;
+using maisim.Game.Graphics.UserInterface;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/maisim/maisim.Game.Tests/Visual/Component/TestSceneMainMenuButton.cs
+++ b/maisim/maisim.Game.Tests/Visual/Component/TestSceneMainMenuButton.cs
@@ -1,4 +1,3 @@
-using maisim.Game.Component;
 using maisim.Game.Graphics.UserInterface;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;

--- a/maisim/maisim.Game/Graphics/UserInterface/BackButton.cs
+++ b/maisim/maisim.Game/Graphics/UserInterface/BackButton.cs
@@ -1,4 +1,3 @@
-using maisim.Game.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.Color4Extensions;
@@ -11,8 +10,9 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
-namespace maisim.Game.Component
+namespace maisim.Game.Graphics.UserInterface
 {
     public class BackButton : Button
     {
@@ -89,15 +89,21 @@ namespace maisim.Game.Component
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            button.FadeColour(MaisimColour.BackButtonColor.Darken(0.5f), 100);
-            scaleContainer.ScaleTo(0.9f, 100, Easing.OutQuint);
+            if (e.Button == MouseButton.Left)
+            {
+                button.FadeColour(MaisimColour.BackButtonColor.Darken(0.5f), 100);
+                scaleContainer.ScaleTo(0.9f, 100, Easing.OutQuint);
+            }
             return base.OnMouseDown(e);
         }
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
-            button.FadeColour(MaisimColour.BackButtonColor, 100);
-            scaleContainer.ScaleTo(1, 100, Easing.OutBack);
+            if (e.Button == MouseButton.Left)
+            {
+                button.FadeColour(MaisimColour.BackButtonColor, 100);
+                scaleContainer.ScaleTo(1, 100, Easing.OutBack);
+            }
             base.OnMouseUp(e);
         }
     }

--- a/maisim/maisim.Game/Graphics/UserInterface/MainMenuButton.cs
+++ b/maisim/maisim.Game/Graphics/UserInterface/MainMenuButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace maisim.Game.Graphics.UserInterface
 {
@@ -105,13 +106,15 @@ namespace maisim.Game.Graphics.UserInterface
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            buttonBox.Colour = buttonColor.Darken(0.5f);
+            if (e.Button == MouseButton.Left)
+                buttonBox.Colour = buttonColor.Darken(0.5f);
             return base.OnMouseDown(e);
         }
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
-            buttonBox.Colour = buttonColor;
+            if (e.Button == MouseButton.Left)
+                buttonBox.Colour = buttonColor;
             base.OnMouseUp(e);
         }
     }

--- a/maisim/maisim.Game/Graphics/UserInterface/MaisimButton.cs
+++ b/maisim/maisim.Game/Graphics/UserInterface/MaisimButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace maisim.Game.Graphics.UserInterface
 {
@@ -64,13 +65,15 @@ namespace maisim.Game.Graphics.UserInterface
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            buttonBox.Colour = buttonColor.Darken(0.5f);
+            if (e.Button == MouseButton.Left)
+                buttonBox.Colour = buttonColor.Darken(0.5f);
             return base.OnMouseDown(e);
         }
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
-            buttonBox.Colour = buttonColor;
+            if (e.Button == MouseButton.Left)
+                buttonBox.Colour = buttonColor;
             base.OnMouseUp(e);
         }
     }

--- a/maisim/maisim.Game/Graphics/UserInterfaceV2/DifficultySelectionButton.cs
+++ b/maisim/maisim.Game/Graphics/UserInterfaceV2/DifficultySelectionButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osuTK.Input;
 
 namespace maisim.Game.Graphics.UserInterfaceV2
 {
@@ -74,15 +75,22 @@ namespace maisim.Game.Graphics.UserInterfaceV2
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            backgroundBox.FadeColour(MaisimColour.GetDifficultyColor(difficultyLevel).Darken(0.5f), 100);
-            mainContainer.ScaleTo(0.9f, 100, Easing.OutQuint);
+            if (e.Button == MouseButton.Left)
+            {
+                backgroundBox.FadeColour(MaisimColour.GetDifficultyColor(difficultyLevel).Darken(0.5f), 100);
+                mainContainer.ScaleTo(0.9f, 100, Easing.OutQuint);
+            }
             return base.OnMouseDown(e);
         }
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
-            backgroundBox.FadeColour(MaisimColour.GetDifficultyColor(difficultyLevel), 100);
-            mainContainer.ScaleTo(1, 500, Easing.OutElastic);
+            if (e.Button == MouseButton.Left)
+            {
+                backgroundBox.FadeColour(MaisimColour.GetDifficultyColor(difficultyLevel), 100);
+                mainContainer.ScaleTo(1, 500, Easing.OutElastic);
+            }
+
             base.OnMouseUp(e);
         }
     }

--- a/maisim/maisim.Game/Screen/SongSelectionScreen.cs
+++ b/maisim/maisim.Game/Screen/SongSelectionScreen.cs
@@ -1,15 +1,12 @@
-using System;
 using maisim.Game.Beatmaps;
-using maisim.Game.Component;
+using maisim.Game.Graphics.UserInterface;
 using maisim.Game.Graphics.UserInterfaceV2;
 using maisim.Game.Utils;
-using NUnit.Framework.Internal;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
-using Logger = osu.Framework.Logging.Logger;
 
 namespace maisim.Game.Screen
 {


### PR DESCRIPTION
This is the problem that I have in mind now since sometime it's annoying when the button has darker when every button has click despite it must be left mouse only. (Also move some element that's already move to a new namespace but the code still use the old namespace)