### PR TITLE
Remove EFCore package from Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,5 @@ updates:
     directory: "maisim/" # Location of package manifests
     schedule:
       interval: "daily"
-    ignore:
-      # Ignore all EFCore update since it's not supported by current .NET version of the project 
-      - dependency-name: "Microsoft.EntityFrameworkCore.Sqlite"
-      - dependency-name: "Microsoft.EntityFrameworkCore.Design"
-      - dependency-name: "Microsoft.EntityFrameworkCore"
     reviewers:
       - "HelloYeew"


### PR DESCRIPTION
Now osu!framework main `Game` package is .NET 6.0 now and we can use the new version of EFCore now.